### PR TITLE
Fix GRPO/eval bugs: greedy gen, KL, returns, eval_every

### DIFF
--- a/rl/env.py
+++ b/rl/env.py
@@ -30,10 +30,15 @@ MAX_STEPS_PER_ROUND = 200  # safety cap to prevent infinite loops
 
 @dataclass
 class Trajectory:
-    """Stores one complete round's worth of (prompt, completion, reward) tuples."""
+    """Stores one complete round's worth of (prompt, completion, reward) tuples.
+
+    decision_steps parallels the other lists: entries with the same id share one game timestep.
+    """
+
     prompts: list[str]
     completions: list[str]
     rewards: list[float]
+    decision_steps: list[int]
     success: bool
     round_num: int
     num_players: int
@@ -68,13 +73,14 @@ def sample_action(
     then map it back to PLAY/WAIT.
     """
     inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
-    output = model.generate(
-        **inputs,
-        max_new_tokens=4,       # short: "PLAY" or "WAIT"
-        do_sample=True,
-        temperature=temperature,
-        pad_token_id=tokenizer.eos_token_id,
-    )
+    # transformers>=4.44 rejects temperature=0 with do_sample=True (division by zero).
+    gen_kwargs = dict(max_new_tokens=4, pad_token_id=tokenizer.eos_token_id)
+    if temperature is not None and temperature > 0:
+        gen_kwargs["do_sample"] = True
+        gen_kwargs["temperature"] = temperature
+    else:
+        gen_kwargs["do_sample"] = False
+    output = model.generate(**inputs, **gen_kwargs)
     new_tokens = output[0][inputs["input_ids"].shape[1]:]
     completion = tokenizer.decode(new_tokens, skip_special_tokens=True)
     return prompt, completion
@@ -98,6 +104,7 @@ def rollout(
     prompts: list[str] = []
     completions: list[str] = []
     step_rewards: list[float] = []
+    decision_steps: list[int] = []
 
     done = False
     step = 0
@@ -130,12 +137,14 @@ def rollout(
             prompts.append(p)
             completions.append(c)
             step_rewards.append(reward)
+            decision_steps.append(step)
 
     success = game.result.value == "success"
     return Trajectory(
         prompts=prompts,
         completions=completions,
         rewards=step_rewards,
+        decision_steps=decision_steps,
         success=success,
         round_num=round_num,
         num_players=num_players,

--- a/rl/train.py
+++ b/rl/train.py
@@ -60,14 +60,26 @@ GRPO_DEFAULTS = dict(
 # Reward shaping
 # ---------------------------------------------------------------------------
 
-def compute_returns(rewards: list[float], gamma: float = 0.99) -> list[float]:
-    """Discounted returns from a list of per-step rewards."""
+def compute_returns(
+    rewards: list[float], decision_steps: list[int], gamma: float = 0.99
+) -> list[float]:
+    """
+    Discounted return per decision. Entries sharing the same game step get the same
+    return-to-go so simultaneous players are not gamma-discounted against each other.
+    """
+    if not rewards:
+        return []
+    step_to_r: dict[int, float] = {}
+    for r, sid in zip(rewards, decision_steps):
+        step_to_r[sid] = r
+    ordered = sorted(step_to_r.keys())
     G = 0.0
-    returns = []
-    for r in reversed(rewards):
+    ret_by_step: dict[int, float] = {}
+    for sid in reversed(ordered):
+        r = step_to_r[sid]
         G = r + gamma * G
-        returns.insert(0, G)
-    return returns
+        ret_by_step[sid] = G
+    return [ret_by_step[sid] for sid in decision_steps]
 
 
 def normalize(values: list[float]) -> list[float]:
@@ -104,7 +116,7 @@ def compute_policy_loss(
     # Collect all trajectory returns and normalize across the group
     all_returns = []
     for traj in trajectories:
-        returns = compute_returns(traj.rewards)
+        returns = compute_returns(traj.rewards, traj.decision_steps)
         all_returns.extend(returns)
     advantages = normalize(all_returns)
 
@@ -113,7 +125,7 @@ def compute_policy_loss(
 
     adv_idx = 0
     for traj in trajectories:
-        traj_returns = compute_returns(traj.rewards)
+        traj_returns = compute_returns(traj.rewards, traj.decision_steps)
         for prompt, completion, _ in zip(traj.prompts, traj.completions, traj_returns):
             adv = advantages[adv_idx]
             adv_idx += 1
@@ -152,8 +164,8 @@ def compute_policy_loss(
             surr2 = ratio.clamp(1 - clip_eps, 1 + clip_eps) * adv_t
             surrogate = -torch.min(surr1, surr2).mean()
 
-            # Approximate KL: KL(old || new) ≈ (log_old - log_new).mean()
-            kl = (comp_old - comp_new).mean()
+            # KL(π_old || π_new) at each position: Σ_a π_old(a) (log π_old(a) − log π_new(a))
+            kl = (comp_old.exp() * (comp_old - comp_new)).sum(dim=-1).mean()
 
             step_loss = surrogate + kl_coef * kl
             total_loss = total_loss + step_loss
@@ -262,6 +274,24 @@ def train(args):
                 f"Win {wins}/{args.group_size} ({win_rate:.0%}) | "
                 f"Loss {loss.item():.4f} | AvgLen {avg_len:.1f}"
             )
+
+        if args.eval_every > 0 and iteration % args.eval_every == 0:
+            model.eval()
+            with torch.no_grad():
+                eval_trajs = batch_rollout(
+                    model=model,
+                    tokenizer=tokenizer,
+                    batch_size=args.group_size,
+                    num_players=args.num_players,
+                    round_num=current_round,
+                    temperature=0.0,
+                )
+            eval_wins = sum(t.success for t in eval_trajs)
+            print(
+                f"  [Eval] greedy {eval_wins}/{len(eval_trajs)} wins "
+                f"({eval_wins / len(eval_trajs):.0%})"
+            )
+            model.train()
 
         if iteration % args.save_every == 0:
             ckpt_path = output_dir / f"iter_{iteration:04d}"


### PR DESCRIPTION
## Summary

This PR fixes four issues in the RL training and evaluation pipeline.

### 1. Evaluation with `temperature=0`
`sample_action` no longer forces `do_sample=True` when temperature is zero, avoiding `ValueError` from recent `transformers` (division by zero on temperature).

### 2. KL penalty
Replaces the mean of `(comp_old - comp_new)` over the vocabulary with the closed-form categorical **KL(π_old ‖ π_new)** per position.

### 3. `eval_every`
Wires the existing CLI flag into the training loop with periodic greedy rollouts and printed win counts.

### 4. Return computation across simultaneous players
Adds `decision_steps` to `Trajectory` and discounts once per **game step**, so players acting at the same timestep get identical return-to-go and are not γ-discounted against each other in the flat list.

## Test plan
- [ ] `python -c` sanity checks for `compute_returns` (optional)
- [ ] `python -m eval.evaluate` with a small model loads and runs without generate errors

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core RL objective math (returns and KL) and alters evaluation behavior, which can materially affect training dynamics and reported metrics.
> 
> **Overview**
> Improves RL rollout/training correctness and stability by supporting *true greedy* action generation when `temperature=0` (disables sampling to avoid `transformers` errors).
> 
> Updates GRPO math: trajectories now track `decision_steps` so return-to-go is discounted **once per game step** (not per player decision), and the KL penalty is replaced with the proper categorical `KL(π_old || π_new)`.
> 
> Hooks `eval_every` into the training loop to run periodic greedy rollouts and print win rates during training.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82da97e6b9cb8fc9e9e1b9465f0a27a1b715f9a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->